### PR TITLE
Update ai_setup_controller.rb

### DIFF
--- a/app/controllers/ai_setup_controller.rb
+++ b/app/controllers/ai_setup_controller.rb
@@ -6,7 +6,7 @@ class AiSetupController < ApplicationController
       @users  = User.all
       @trackers   = Tracker.all
       #puts @projects
-      @flows    = Autoasigned.find(:all,  :order => "autoasigneds.id_project DESC")
+      @flows    = Autoasigned.all.order "id_project desc"
   end
 
   def change


### PR DESCRIPTION
Method find(:all) deprecated and in 3.4 cause an error